### PR TITLE
Run demos as user vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-d
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
-
+USER $USER_UID:$USER_GID
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,8 +13,8 @@ services:
             NODE_VERSION: "lts/*"
             INSTALL_AZURE_CLI: "false"
             # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-            USER_UID: 1000
-            USER_GID: 1000
+            USER_UID: ${UID:-1000}
+            USER_GID: ${GID:-1000}
 
       volumes:
          - ..:/workspace:cached

--- a/.devcontainer/shipping-database-init.sql
+++ b/.devcontainer/shipping-database-init.sql
@@ -1,5 +1,5 @@
 create table shipments (
     id SERIAL,
     order_id TEXT,
-    ready BOOLEAN,
+    ready BOOLEAN
 );


### PR DESCRIPTION
It is preferable to run the container as non-root user and configure the devcontainer user setting the same UID:GID of the one running the container in the host machine.

I applied this settings using the USER instruction in the Dockerfile and made the docker-compose a little more flexible.
With this changes, whenever the docker-compose is run it will use the values of the $UID and $GID env variables if they are set or default it to 1000.

⚠️  not tested on Windows/MacOS

```console
$ ./build.sh
....
Time Elapsed 00:00:02.35
Targets: build/src/volume-01/arch/cmd-events-rec/Demo.sln: Succeeded (2.76 s)
Targets: build: Succeeded (35.31 s)
Targets: test: No inputs!
Targets: default: Succeeded
Targets: ────────────────────────────────────────────────────────────────────────────────
Targets: Target                                            Outcome     Duration          
Targets: ────────────────────────────────────────────────  ──────────  ──────────────────
Targets: build                                             Succeeded   35.31 s    100.0% 
Targets:   src/volume-01/sagas/timeouts/Demo.sln           Succeeded   ├─14.75 s  ├─41.8%
Targets:   src/volume-01/sagas/basic-saga/Demo.sln         Succeeded   ├─3.60 s   ├─10.2%
Targets:   src/volume-01/req-resp/req-resp/Demo.sln        Succeeded   ├─2.42 s   ├─6.8% 
Targets:   src/volume-01/req-resp/req-multi-resp/Demo.sln  Succeeded   ├─2.03 s   ├─5.7% 
Targets:   src/volume-01/req-resp/basic-send/Demo.sln      Succeeded   ├─2.01 s   ├─5.7% 
Targets:   src/volume-01/pub-sub/pub-multi-sub/Demo.sln    Succeeded   ├─2.53 s   ├─7.2% 
Targets:   src/volume-01/pub-sub/basic-pub-sub/Demo.sln    Succeeded   ├─2.24 s   ├─6.3% 
Targets:   src/volume-01/arch/cmd-events/Demo.sln          Succeeded   ├─2.97 s   ├─8.4% 
Targets:   src/volume-01/arch/cmd-events-rec/Demo.sln      Succeeded   └─2.76 s   └─7.8% 
Targets: test                                              No inputs!                    
Targets: default                                           Succeeded                     
Targets: ────────────────────────────────────────────────────────────────────────────────
Targets: Succeeded (default) (35.31 s)
```