### PR TITLE
Remove reference to non existing project

### DIFF
--- a/vol-2/lesson-3/src/Warehouse.Service/Warehouse.Service.csproj
+++ b/vol-2/lesson-3/src/Warehouse.Service/Warehouse.Service.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Shared\NServiceBus.Shared.csproj" />
-    <ProjectReference Include="..\Sales.Messages.Events\Sales.Messages.Events.csproj" />
     <ProjectReference Include="..\Warehouse.Data\Warehouse.Data.csproj" />
     <ProjectReference Include="..\Warehouse.Messages\Warehouse.Messages.csproj" />
   </ItemGroup>


### PR DESCRIPTION
`Warehouse.Service` project in lesson 3 references a non-existing project (it'll be added in lesson 4). It should not be a problem, a missing project should be a regular MSBuild warning.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/1325611/168742646-d734eb15-cfd8-4a56-a479-0c5cd4abda99.png">

However, for some users, it turns out that OmniSharp treats that like an error:

> [warn]: OmniSharp.MSBuild.ProjectLoader
        The referenced project '../Sales.Messages.Events/Sales.Messages.Events.csproj' does not exist.
[info]: OmniSharp.MSBuild.ProjectManager
        Successfully loaded project file '/workspace/src/Warehouse.Service/Warehouse.Service.csproj'.
/workspace/src/Warehouse.Service/Warehouse.Service.csproj
/root/.vscode-server/extensions/ms-dotnettools.csharp-1.24.4-linux-x64/.omnisharp/1.38.2/omnisharp/.msbuild/Current/Bin/Microsoft.Common.CurrentVersion.targets(2065,5): Error: The referenced project '../Sales.Messages.Events/Sales.Messages.Events.csproj' does not exist.

This PR removes the reference that is, indeed, not needed in lesson 3
